### PR TITLE
Add logging and ready check initialization for 1.6 compatibility

### DIFF
--- a/MultiplayerAssistant/HostAutomatorStages/ReadyCheckHelper.cs
+++ b/MultiplayerAssistant/HostAutomatorStages/ReadyCheckHelper.cs
@@ -1,4 +1,6 @@
+using MultiplayerAssistant;
 using Netcode;
+using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Locations;
 using StardewValley.Network;
@@ -11,88 +13,100 @@ namespace MultiplayerAssistant.HostAutomatorStages
 {
     internal class ReadyCheckHelper
     {
-        private static Assembly assembly = typeof(Game1).Assembly;
-        private static Type readyCheckType = assembly.GetType("StardewValley.ReadyCheck");
-        private static Type netRefType = typeof(NetRef<>);
-        private static Type readyCheckNetRefType = (readyCheckType != null) ? netRefType.MakeGenericType(readyCheckType) : null;
-        private static Type netStringDictionaryType = typeof(NetStringDictionary<,>);
-        private static Type readyCheckDictionaryType = (readyCheckNetRefType != null && readyCheckType != null) ? netStringDictionaryType.MakeGenericType(readyCheckType, readyCheckNetRefType) : null;
+        private static IMonitor? monitor;
+        private static readonly Assembly assembly = typeof(Game1).Assembly;
+        private static readonly Type? readyCheckType = assembly.GetType("StardewValley.ReadyCheck");
+        private static readonly Type netRefType = typeof(NetRef<>);
+        private static readonly Type? readyCheckNetRefType = readyCheckType != null ? netRefType.MakeGenericType(readyCheckType) : null;
+        private static readonly Type netStringDictionaryType = typeof(NetStringDictionary<,>);
+        private static readonly Type? readyCheckDictionaryType = readyCheckNetRefType != null && readyCheckType != null ? netStringDictionaryType.MakeGenericType(readyCheckType, readyCheckNetRefType) : null;
 
-        private static FieldInfo readyChecksFieldInfo = typeof(FarmerTeam).GetField("readyChecks", BindingFlags.NonPublic | BindingFlags.Instance);
-        private static object readyChecks = null;
+        private static readonly FieldInfo? readyChecksFieldInfo = typeof(FarmerTeam).GetField("readyChecks", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static object? readyChecks = null;
 
-        private static MethodInfo readyChecksAddMethodInfo = (readyCheckDictionaryType != null && readyCheckType != null) ? readyCheckDictionaryType.GetMethod("Add", new Type[] { typeof(string), readyCheckType }) : null;
-        private static PropertyInfo readyChecksItemPropertyInfo = readyCheckDictionaryType?.GetProperty("Item");
+        private static readonly MethodInfo? readyChecksAddMethodInfo = readyCheckDictionaryType != null && readyCheckType != null ? readyCheckDictionaryType.GetMethod("Add", new Type[] { typeof(string), readyCheckType }) : null;
+        private static readonly PropertyInfo? readyChecksItemPropertyInfo = readyCheckDictionaryType?.GetProperty("Item");
 
-        private static FieldInfo readyPlayersFieldInfo = readyCheckType?.GetField("readyPlayers", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static readonly FieldInfo? readyPlayersFieldInfo = readyCheckType?.GetField("readyPlayers", BindingFlags.NonPublic | BindingFlags.Instance);
 
-        private static Dictionary<string, NetFarmerCollection> readyPlayersDictionary = new Dictionary<string, NetFarmerCollection>();
+        private static Dictionary<string, NetFarmerCollection> readyPlayersDictionary = new();
+
+        public static void Initialize(IMonitor monitor)
+        {
+            ReadyCheckHelper.monitor = monitor ?? throw new ArgumentNullException(nameof(monitor));
+            Debug("ReadyCheckHelper 初始化完成");
+        }
 
         public static void OnDayStarted(object sender, StardewModdingAPI.Events.DayStartedEventArgs e)
         {
-            // 基本防御：若反射类型不可用则直接返回，避免空引用
             if (readyCheckType == null || readyChecksFieldInfo == null || readyChecksItemPropertyInfo == null)
             {
+                Warn("ReadyCheck 反射信息缺失，无法刷新缓存");
                 return;
             }
+
+            Debug("OnDayStarted 触发，准备刷新 ReadyCheck 缓存");
             if (readyChecks == null)
             {
                 readyChecks = readyChecksFieldInfo.GetValue(Game1.player.team);
+                Debug("已获取 FarmerTeam.readyChecks 引用");
             }
 
-            // 新的一天开始时，清理上一晚遗留的睡觉就绪与公告状态，避免早晨误判为仍在睡觉导致循环弹窗
             try
             {
-                // 1) 清空 announcedSleepingFarmers
                 Game1.player?.team?.announcedSleepingFarmers?.Clear();
+                Debug("已清空 announcedSleepingFarmers");
 
-                // 2) 清空 ReadyCheck("sleep") 的 readyPlayers 集合
-                object sleepReadyCheck = null;
+                object? sleepReadyCheck = null;
                 try
                 {
                     sleepReadyCheck = Activator.CreateInstance(readyCheckType, new object[] { "sleep" });
                     readyChecksAddMethodInfo?.Invoke(readyChecks, new object[] { "sleep", sleepReadyCheck });
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    Trace($"使用缓存 ReadyCheck(sleep)：{ex.Message}");
                     sleepReadyCheck = readyChecksItemPropertyInfo.GetValue(readyChecks, new object[] { "sleep" });
                 }
-                var readyPlayers = (NetFarmerCollection)(readyPlayersFieldInfo?.GetValue(sleepReadyCheck));
-                readyPlayers?.Clear();
 
-                // 同步我们维护的缓存字典
+                var readyPlayers = (NetFarmerCollection?)(readyPlayersFieldInfo?.GetValue(sleepReadyCheck));
+                readyPlayers?.Clear();
+                Debug("已重置 sleep ReadyCheck 的 readyPlayers 集合");
+
                 if (readyPlayersDictionary.ContainsKey("sleep"))
                 {
                     readyPlayersDictionary["sleep"] = readyPlayers ?? new NetFarmerCollection();
                 }
             }
-            catch
+            catch (Exception ex)
             {
-                // 忽略清理异常，避免影响游戏流程
+                Warn($"刷新 sleep ReadyCheck 时出现异常：{ex.Message}");
             }
 
-            //Checking mailbox sometimes gives some gold, but it's compulsory to unlock some events
-            for (int i = 0; i < 10; ++i) {
+            for (int i = 0; i < 10; ++i)
+            {
                 Game1.getFarm().mailbox();
             }
 
-            //Unlocks the sewer（1.6 事件ID改为字符串）
-            if (!Game1.player.eventsSeen.Contains("295672") && Game1.netWorldState.Value.MuseumPieces.Count() >= 60) {
+            if (!Game1.player.eventsSeen.Contains("295672") && Game1.netWorldState.Value.MuseumPieces.Count() >= 60)
+            {
                 Game1.player.eventsSeen.Add("295672");
+                Debug("自动解锁下水道事件 (295672)");
             }
 
-            //Upgrade farmhouse to match highest level cabin
             var targetLevel = Game1.getFarm().buildings.Where(o => o.isCabin).Select(o => ((Cabin)o.indoors.Value).upgradeLevel).DefaultIfEmpty(0).Max();
-            if (targetLevel > Game1.player.HouseUpgradeLevel) {
+            if (targetLevel > Game1.player.HouseUpgradeLevel)
+            {
                 Game1.player.HouseUpgradeLevel = targetLevel;
                 Game1.player.performRenovation("FarmHouse");
+                Debug($"同步房屋升级等级：{targetLevel}");
             }
-            
 
-            Dictionary<string, NetFarmerCollection> newReadyPlayersDictionary = new Dictionary<string, NetFarmerCollection>();
+            var newReadyPlayersDictionary = new Dictionary<string, NetFarmerCollection>();
             foreach (var checkName in readyPlayersDictionary.Keys)
             {
-                object readyCheck = null;
+                Trace($"刷新 ReadyCheck：{checkName}");
+                object? readyCheck = null;
                 try
                 {
                     if (readyCheckType != null)
@@ -101,37 +115,41 @@ namespace MultiplayerAssistant.HostAutomatorStages
                         readyChecksAddMethodInfo?.Invoke(readyChecks, new object[] { checkName, readyCheck });
                     }
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
-                    readyCheck = readyChecksItemPropertyInfo.GetValue(readyChecks, new object[] { checkName });
+                    Trace($"复用现有 ReadyCheck {checkName}：{ex.Message}");
+                    readyCheck = readyChecksItemPropertyInfo?.GetValue(readyChecks, new object[] { checkName });
                 }
 
-                NetFarmerCollection readyPlayers = (NetFarmerCollection) (readyPlayersFieldInfo?.GetValue(readyCheck));
-                // 为空则给一个空集合，避免可空性警告
-                var rc = readyPlayers ?? new NetFarmerCollection();
-                newReadyPlayersDictionary.Add(checkName, rc);
+                var readyPlayers = (NetFarmerCollection?)(readyPlayersFieldInfo?.GetValue(readyCheck));
+                newReadyPlayersDictionary.Add(checkName, readyPlayers ?? new NetFarmerCollection());
             }
+
             readyPlayersDictionary = newReadyPlayersDictionary;
+            Trace($"当前监控 ReadyCheck 数量：{readyPlayersDictionary.Count}");
         }
 
         public static void WatchReadyCheck(string checkName)
         {
             readyPlayersDictionary.TryAdd(checkName, null);
+            Debug($"记录监听 ReadyCheck：{checkName}");
         }
 
-        // Prerequisite: OnDayStarted() must have been called at least once prior to this method being called.
         public static bool IsReady(string checkName, Farmer player)
         {
             if (readyCheckType == null || readyChecksItemPropertyInfo == null)
             {
+                Warn($"ReadyCheck 反射信息缺失，无法判断 {checkName}");
                 return false;
             }
-            if (readyPlayersDictionary.TryGetValue(checkName, out NetFarmerCollection readyPlayers) && readyPlayers != null)
+
+            if (readyPlayersDictionary.TryGetValue(checkName, out var readyPlayers) && readyPlayers != null)
             {
+                Trace($"从缓存读取 ReadyCheck：{checkName}, player={player?.Name}");
                 return readyPlayers.Contains(player);
             }
 
-            object readyCheck = null;
+            object? readyCheck = null;
             try
             {
                 if (readyCheckType != null)
@@ -140,22 +158,44 @@ namespace MultiplayerAssistant.HostAutomatorStages
                     readyChecksAddMethodInfo?.Invoke(readyChecks, new object[] { checkName, readyCheck });
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                readyCheck = readyChecksItemPropertyInfo.GetValue(readyChecks, new object[] { checkName });
+                Trace($"复用 ReadyCheck {checkName}：{ex.Message}");
+                readyCheck = readyChecksItemPropertyInfo?.GetValue(readyChecks, new object[] { checkName });
             }
 
-            readyPlayers = (NetFarmerCollection) (readyPlayersFieldInfo?.GetValue(readyCheck));
+            readyPlayers = (NetFarmerCollection?)(readyPlayersFieldInfo?.GetValue(readyCheck));
             var rc2 = readyPlayers ?? new NetFarmerCollection();
             if (readyPlayersDictionary.ContainsKey(checkName))
             {
                 readyPlayersDictionary[checkName] = rc2;
-            } else
+            }
+            else
             {
-                readyPlayersDictionary.Add(checkName , rc2);
+                readyPlayersDictionary.Add(checkName, rc2);
             }
 
-            return rc2.Contains(player);
+            var result = rc2.Contains(player);
+            Trace($"刷新 ReadyCheck 状态：{checkName}, player={player?.Name}, result={result}");
+            return result;
+        }
+
+        private static void Debug(string message)
+        {
+            if (monitor != null)
+                monitor.Debug(message, nameof(ReadyCheckHelper));
+        }
+
+        private static void Trace(string message)
+        {
+            if (monitor != null)
+                monitor.Trace(message, nameof(ReadyCheckHelper));
+        }
+
+        private static void Warn(string message)
+        {
+            if (monitor != null)
+                monitor.Warn(message, nameof(ReadyCheckHelper));
         }
     }
 }

--- a/MultiplayerAssistant/HostAutomatorStages/StartFarmStage.cs
+++ b/MultiplayerAssistant/HostAutomatorStages/StartFarmStage.cs
@@ -35,6 +35,7 @@ namespace MultiplayerAssistant.HostAutomatorStages
         {
             this.monitor = monitor;
             this.config = config;
+            ReadyCheckHelper.Initialize(monitor);
             helper.Events.GameLoop.SaveLoaded += onSaveLoaded;
             if (config.EnableCropSaver) {
                 cropSaver = new CropSaver(helper, monitor, config);

--- a/MultiplayerAssistant/Services/ConfirmationTimeoutService.cs
+++ b/MultiplayerAssistant/Services/ConfirmationTimeoutService.cs
@@ -31,18 +31,21 @@ namespace MultiplayerAssistant.Services
         public void Enable()
         {
             helper.Events.GameLoop.UpdateTicked += OnUpdate;
+            monitor.Debug("ConfirmationTimeoutService 已启用", nameof(ConfirmationTimeoutService));
         }
 
         public void Disable()
         {
             helper.Events.GameLoop.UpdateTicked -= OnUpdate;
             items.Clear();
+            monitor.Debug("ConfirmationTimeoutService 已禁用并清空条目", nameof(ConfirmationTimeoutService));
         }
 
         public void AddTimeoutSeconds(int seconds, Action callback)
         {
             if (seconds <= 0 || callback == null)
                 return;
+            monitor.Debug($"新增确认超时：{seconds}s", nameof(ConfirmationTimeoutService));
             items.Add(new TimeoutItem
             {
                 DueUtc = DateTime.UtcNow.AddSeconds(seconds).Ticks,
@@ -60,6 +63,7 @@ namespace MultiplayerAssistant.Services
                 if (!it.Fired && nowTicks >= it.DueUtc)
                 {
                     it.Fired = true;
+                    monitor.Debug("触发确认超时回调", nameof(ConfirmationTimeoutService));
                     try { it.Callback?.Invoke(); }
                     catch (Exception ex) { monitor.Exception(ex, "确认超时回调异常", nameof(ConfirmationTimeoutService)); }
                 }


### PR DESCRIPTION
## Summary
- initialize the ready-check helper with the active monitor so it can log its new compatibility checks against the updated API
- add defensive debug/trace logging while refreshing ready-check caches and when confirmation timeouts are created or fired

## Testing
- `dotnet build` *(fails: `dotnet` CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cca8a9e5b8832fbf0b5eac96067ffb